### PR TITLE
Add messaging for Windows 11 $I files

### DIFF
--- a/RBCmd/Program.cs
+++ b/RBCmd/Program.cs
@@ -496,7 +496,7 @@ public class Program
 
         if (di.Format == 2)
         {
-            os = "Windows 10";
+            os = "Windows 10/11";
         }
 
         Console.WriteLine();


### PR DESCRIPTION
Windows 11 $I files are the same version as they were in Windows 10

![010Editor_4PXy8rQ6eL](https://user-images.githubusercontent.com/36825567/155767886-6b214225-06f1-4fb7-834c-08f16f25641e.gif)

