### PR TITLE
Cap FluentAssertions to Open Licence

### DIFF
--- a/RecycleBin.Test/RecycleBin.Test.csproj
+++ b/RecycleBin.Test/RecycleBin.Test.csproj
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\RecycleBin\RecycleBin.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
     <PackageReference Include="NUnit" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Due to the mess of [here](https://github.com/fluentassertions/fluentassertions/pull/2943). Protects against License Change 